### PR TITLE
add github out domain & perms

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -12,12 +12,14 @@ export default Manifest({
     "Slack bot that tracks GitHub PR status and provides team visibility",
   icon: "assets/default_new_app_icon.png",
   workflows: [], // Will add PR tracking workflows in Phase 2
-  outgoingDomains: [],
+  outgoingDomains: ["api.github.com"],
   datastores: [SampleObjectDatastore],
   botScopes: [
     "commands",
     "chat:write",
     "chat:write.public",
+    "channels:history", // Read messages to detect PRs
+    "reactions:write", // React to acknowledge PR detection
     "datastore:read",
     "datastore:write",
   ],


### PR DESCRIPTION
# Summary of Changes

## New Bot Scopes Added

  - ✅ channels:history - Enables reading messages to detect GitHub PR URLs
  - ✅ reactions:write - Allows bot to react with ✅ when PRs are successfully tracked

## Outgoing Domains Updated

  - ✅ api.github.com - Enables GitHub REST API calls for PR metadata and status

## Verification Passed

  - ✅ deno check manifest.ts - Compilation successful
  - ✅ deno fmt --check - Code formatting perfect
  - ✅ deno lint - No linting issues

## Updated Manifest Configuration

  The manifest now includes all permissions needed for PR tracking:

  botScopes: [
    "commands",
    "chat:write",
    "chat:write.public",
    "channels:history",    // NEW: Read messages to detect PRs
    "reactions:write",     // NEW: React to acknowledge PR detection
    "datastore:read",
    "datastore:write",
  ],
  outgoingDomains: ["api.github.com"], // NEW: GitHub API access

# Security & Permission Notes

  - channels:history is a sensitive permission but required for message event processing
  - GitHub API domain is within the 10-domain limit
  - Comments added to explain the purpose of each new permission
  - Ready for workspace deployment when Phase 1 is complete